### PR TITLE
headerオプションがない場合に各データ名が表示されないので修正してみました。

### DIFF
--- a/lib/task/opCsvExportTask.class.php
+++ b/lib/task/opCsvExportTask.class.php
@@ -38,7 +38,7 @@ class opCsvExportTask extends sfDoctrineBaseTask
   {
     new sfDatabaseManager($this->configuration);
 
-    if ('true' === $options['header'])
+    if ('true' == $options['header'])
     {
       echo $this->getHeader()."\n";
     }


### PR DESCRIPTION
 Fixed a bug where each data name will not be displayed if you do not have the option header
