### PR TITLE
(fixed #4227) プロフィール項目に複数選択(チェックボックス)の項目がありいずれかが選択されている場合、単一選択(プルダウン)、単一選択(ラジオボタン)の選択値が出力されない問題を修正

### DIFF
--- a/lib/model/opMemberCsvList.class.php
+++ b/lib/model/opMemberCsvList.class.php
@@ -348,12 +348,22 @@ class opMemberCsvList
           {
             $profileDatas = $memberProfileList[$memberId];
             $optionValue = array();
+            $existsChildProfile = false;
             foreach ($profileDatas as $profileData)
             {
               $childProfileId = $profileData['p_profile_id'];
               if ($childProfileId == $profileRootId)
               {
                 $optionId = $profileData['p_profile_option_id'];
+                $optionValue[] = $profileOptionTranslationList[$optionId];
+                $existsChildProfile = true;
+              }
+            }
+            if (!$existsChildProfile)
+            {
+              $optionId = $profileRootData['p_profile_option_id'];
+              if (isset($optionId))
+              {
                 $optionValue[] = $profileOptionTranslationList[$optionId];
               }
             }


### PR DESCRIPTION
http://redmine.openpne.jp/issues/4227